### PR TITLE
fix: Support Uint8Array and Blob in onmessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timeleap/client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "packageManager": "yarn@4.5.2",
   "devDependencies": {
     "@types/node": "^22.10.7",

--- a/src/client.ts
+++ b/src/client.ts
@@ -43,8 +43,11 @@ export class Client {
   }
 
   async onmessage(event: MessageEvent) {
-    const data = event.data as Blob;
-    const buf = new Uint8Array(await data.arrayBuffer());
+    const data = event.data;
+    const buf =
+      data instanceof Uint8Array
+        ? data
+        : new Uint8Array(await (data as Blob).arrayBuffer());
     const sia = new Sia(buf);
     const opcode = sia.readByteArrayN(1);
 


### PR DESCRIPTION
## Context

The `onmessage` handler in Client assumed that incoming WebSocket messages were always `Blob` objects, which fails in some runtimes (e.g. Bun) where `Uint8Array` is used directly.

## Proposed solution 
```js
const buf =
  data instanceof Uint8Array
    ? data
    : new Uint8Array(await (data as Blob).arrayBuffer());
```

## Impact
- Fixes compatibility with Bun
- Still works in Node.js and browser
- No API changes
